### PR TITLE
Dynamic java path in filebot-arch.sh

### DIFF
--- a/filebot-arch.sh
+++ b/filebot-arch.sh
@@ -5,7 +5,7 @@ export LANG="en_US.UTF-8"
 export LC_ALL="en_US.UTF-8"
 
 APP_ROOT=/usr/share/java/filebot
-
+JAVA="$(which java)"
 # add APP_ROOT to LD_LIBRARY_PATH
 if [ ! -z "$LD_LIBRARY_PATH" ]; then
 	export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:$APP_ROOT"
@@ -19,5 +19,5 @@ EXTRACTOR="ApacheVFS"			# use Apache Commons VFS2 with junrar plugin
 # EXTRACTOR="SevenZipNativeBindings"	# use the lib7-Zip-JBinding.so native library
 
 # start filebot
-/usr/lib/jvm/java-8-openjdk/bin/java -Dunixfs=false -DuseGVFS=false -DuseExtendedFileAttributes=true -DuseCreationDate=false -Djava.net.useSystemProxies=false -Dapplication.deployment=AUR -Dfile.encoding="UTF-8" -Dsun.jnu.encoding="UTF-8" -Djna.nosys=false -Djna.nounpack=true -Dnet.filebot.Archive.extractor="$EXTRACTOR" -Dnet.filebot.AcoustID.fpcalc="fpcalc" -Dapplication.dir=$HOME/.config/filebot -Djava.io.tmpdir=/tmp/filebot -Dapplication.update=skip -Djna.library.path=/usr/share/java/filebot $JAVA_OPTS -cp /usr/share/java/filebot/filebot.jar net.filebot.Main "$@"
+"${JAVA}" -Dunixfs=false -DuseGVFS=false -DuseExtendedFileAttributes=true -DuseCreationDate=false -Djava.net.useSystemProxies=false -Dapplication.deployment=AUR -Dfile.encoding="UTF-8" -Dsun.jnu.encoding="UTF-8" -Djna.nosys=false -Djna.nounpack=true -Dnet.filebot.Archive.extractor="$EXTRACTOR" -Dnet.filebot.AcoustID.fpcalc="fpcalc" -Dapplication.dir=$HOME/.config/filebot -Djava.io.tmpdir=/tmp/filebot -Dapplication.update=skip -Djna.library.path=/usr/share/java/filebot $JAVA_OPTS -cp /usr/share/java/filebot/filebot.jar net.filebot.Main "$@"
 


### PR DESCRIPTION
It looks like the arch package for openjdk 8 moved (or removed a symlink) for java. This patch determines the correct path for java at runtime.