### PR TITLE
Introduce PGP keys and increase readability

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = filebot
 	pkgdesc = The ultimate TV and Movie Renamer
-	pkgver = 4.9.4
-	pkgrel = 2
+	pkgver = 4.9.5
+	pkgrel = 0
 	url = https://www.filebot.net/
 	install = filebot.install
 	arch = i686
@@ -20,9 +20,12 @@ pkgbase = filebot
 	provides = filebot
 	conflicts = filebot47
 	conflicts = filebot-git
-	source = https://get.filebot.net/filebot/FileBot_4.9.4/FileBot_4.9.4-aur.tar.xz
+	source = https://get.filebot.net/filebot/FileBot_4.9.5/FileBot_4.9.5-aur.tar.xz
+	source = https://get.filebot.net/filebot/FileBot_4.9.5/FileBot_4.9.5-aur.tar.xz.asc
 	source = filebot.sh
-	md5sums = 8d1bb833a598382048f9ce574dba0e73
-	md5sums = 9b7ba1e301b3f4c8b9a751d6a00414ea
+	validpgpkeys = B0976E51E5C047AD0FD051294E402EBF7C3C6A71
+	sha256sums = 42374d6a3f69351dec868de70591c14264b9c470ce04359e8034823f4e0e57a1
+	sha256sums = 50b59c25617651b3b802ac8cdcb9a9204cfae2ce7c71d6f0dd5a3e2039f5afd4
+	sha256sums = cf902ce1b126706d7f1c4bb3bb32002ed2c12170d97b13070f8a1202a2e6b123
 
 pkgname = filebot

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.xz
+*.xz.asc
 *.tar.gz
+*.tar.gz.asc
 *.pkg.tar*
 src/
 pkg/

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -7,13 +7,12 @@
 # Contributor: Nathan Owe <ndowens04 at gmail>
 
 pkgname=filebot
-pkgver=4.9.4
-pkgrel=2
+pkgver=4.9.5
+pkgrel=0
 pkgdesc="The ultimate TV and Movie Renamer"
 arch=('i686' 'x86_64' 'aarch64' 'armv7l' 'armv7h')
 url="https://www.filebot.net/"
 license=('Commercial')
-#groups=()
 depends=('jre11-openjdk' 'java11-openjfx>=11.0.10.u1' 'fontconfig' 'chromaprint')
 makedepends=()
 checkdepends=()
@@ -25,37 +24,23 @@ optdepends=('libzen: Required by libmediainfo'
 provides=('filebot')
 
 conflicts=('filebot47' 'filebot-git')
-#replaces=()
-#backup=()
-#options=()
 install=$pkgname.install
-#changelog=
-source=("https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz"
-         "filebot.sh")
+source=(
+    "https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz"
+    "https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz.asc"
+    "filebot.sh"
+)
 
-#noextract=()
-md5sums=('8d1bb833a598382048f9ce574dba0e73'
-         '9b7ba1e301b3f4c8b9a751d6a00414ea')
-#validpgpkeys=()
-
-#prepare() {}
-
-#build() {}
-
-#check() {}
+sha256sums=('42374d6a3f69351dec868de70591c14264b9c470ce04359e8034823f4e0e57a1'
+            '50b59c25617651b3b802ac8cdcb9a9204cfae2ce7c71d6f0dd5a3e2039f5afd4'
+            'cf902ce1b126706d7f1c4bb3bb32002ed2c12170d97b13070f8a1202a2e6b123')
+validpgpkeys=('B0976E51E5C047AD0FD051294E402EBF7C3C6A71')
 
 package() {
-  mkdir -p $pkgdir/usr/bin
-  # mkdir -p $pkgdir/usr/share/$pkgname/openjfx
-  mkdir -p $pkgdir/usr/share/$pkgname
+  mkdir -p "${pkgdir}/usr/bin"
+  mkdir -p "${pkgdir}/usr/share/${pkgname}"
  
-  install -Dm755 $pkgname.sh "$pkgdir/usr/bin/$pkgname"
+  install -Dm755 "${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
 
-  cd $srcdir
-  
-  # cp -dpr --no-preserve=ownership * "$pkgdir"
-  cp -dpr --no-preserve=ownership etc usr "$pkgdir"
-  
-  # ln -sf $srcdir/usr/share/$pkgname/bin/$pkgname.sh $pkgdir/usr/bin/$pkgname
-
+  cp -dpr --no-preserve=ownership "${srcdir}/etc" "${srcdir}/usr" "${pkgdir}"
 }

--- a/filebot.install
+++ b/filebot.install
@@ -1,3 +1,4 @@
+# vim: set syntax=bash :
 pre_install () {
 if [ -d "/usr/share/filebot/openjfx" ]; then
   if [ -L "/usr/share/filebot/openjfx" ]; then
@@ -10,31 +11,29 @@ fi
 }
 
 post_install() {
-echo -e "\e[1;33m==>\e[0m Symlinking OpenJFX"
-cd /usr/share/filebot
+  echo -e "\e[1;33m==>\e[0m Symlinking OpenJFX"
 
-ln -sf /usr/lib/jvm/java-11-openjfx/lib/ openjfx
+  ln -sf /usr/lib/jvm/java-11-openjfx/lib/ /usr/share/filebot/openjfx
 
-echo ""
+  echo ""
+  echo -e "\e[1;33m==>\e[0m \e[1;31m filebot --license license.file \e[0m will activate your license.file"
+  echo ""
 
-echo -e "\e[1;33m==>\e[0m \e[1;31m filebot --license license.file \e[0m will activate your license.file"
-echo ""
-
-echo -e "\e[1;33m==>\e[0m To enable system extractor for archives please run"
-echo -e ""
-echo -e "\e[1;33m==>\e[0m \e[1;31m filebot -script fn:properties --def net.filebot.archive.extractor=ShellExecutables \e[0m"
-echo ""
+  echo -e "\e[1;33m==>\e[0m To enable system extractor for archives please run"
+  echo ""
+  echo -e "\e[1;33m==>\e[0m \e[1;31m filebot -script fn:properties --def net.filebot.archive.extractor=ShellExecutables \e[0m"
+  echo ""
 }
 
 pre_upgrade () {
-  pre_install $1
+  pre_install "${1}"
 }
 
 post_upgrade() {
-  post_install $1
+  post_install "${1}"
 }
 
 pre_remove() {
-echo -e "\e[1;33m==>\e[0m Removing OpenJFX symlinks leftover"
-rm /usr/share/filebot/openjfx
+  echo -e "\e[1;33m==>\e[0m Removing OpenJFX symlinks leftover"
+  rm /usr/share/filebot/openjfx
 }

--- a/filebot.sh
+++ b/filebot.sh
@@ -1,21 +1,65 @@
-#!/bin/sh
+#!/usr/bin/env bash
 FILEBOT_HOME="/usr/share/filebot"
 
-
 # sanity check
-if [ -z "$HOME" ]; then
-	echo '$HOME must be set'
+if [ -z "${HOME}" ]; then
+	echo "\$HOME must be set"
 	exit 1
 fi
 
-if [ "$EUID" = "0" ]; then
+if [ "$(id -u)" = "0" ]; then
 	echo "$0 must NOT run as root"
 fi
 
-
 # select application data folder
-APP_DATA="$HOME/.config/filebot"
-LIBRARY_PATH="$FILEBOT_HOME/lib/$(uname -m):/lib64"
-MODULE_PATH="$FILEBOT_HOME/openjfx"
+APP_DATA="${HOME}/.config/filebot"
+LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"
+MODULE_PATH="${FILEBOT_HOME}/openjfx"
 
-/usr/lib/jvm/java-11-openjdk/bin/java -Dapplication.deployment=aur --module-path "$MODULE_PATH" --add-modules ALL-MODULE-PATH -Dapplication.update=skip -Dnet.filebot.archive.extractor=ShellExecutables --illegal-access=permit --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens=java.base/java.lang.reflect=ALL-UNNAMED --add-opens=java.base/java.lang.invoke=ALL-UNNAMED --add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.util.function=ALL-UNNAMED --add-opens=java.base/java.util.regex=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.base/java.nio=ALL-UNNAMED --add-opens=java.base/java.nio.file=ALL-UNNAMED --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED --add-opens=java.base/java.nio.channels=ALL-UNNAMED --add-opens=java.base/java.nio.charset=ALL-UNNAMED --add-opens=java.base/java.time=ALL-UNNAMED --add-opens=java.base/java.time.chrono=ALL-UNNAMED --add-opens=java.base/java.util.concurrent=ALL-UNNAMED --add-opens=java.base/java.text=ALL-UNNAMED --add-opens=java.base/sun.nio.fs=ALL-UNNAMED --add-opens=java.logging/java.util.logging=ALL-UNNAMED --add-opens=java.desktop/java.awt=ALL-UNNAMED --add-opens=java.desktop/sun.awt=ALL-UNNAMED --add-opens=java.desktop/sun.swing=ALL-UNNAMED --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED -Djna.boot.library.path="$LIBRARY_PATH" -Djna.library.path="$LIBRARY_PATH" -Djava.library.path="$LIBRARY_PATH" -Dapplication.dir="$APP_DATA" -Dapplication.cache="$APP_DATA/cache" -Djava.io.tmpdir="$APP_DATA/tmp" -Dfile.encoding="UTF-8" -Dsun.jnu.encoding="UTF-8" -Dprism.order=sw -Dnet.filebot.theme=Darcula -DuseGVFS=true -Dnet.filebot.gio.GVFS="$XDG_RUNTIME_DIR/gvfs" $JAVA_OPTS $FILEBOT_OPTS -jar "$FILEBOT_HOME/jar/filebot.jar" "$@"
+/usr/lib/jvm/java-11-openjdk/bin/java \
+    -Dapplication.deployment=aur \
+    --module-path "${MODULE_PATH}" \
+    --add-modules ALL-MODULE-PATH \
+    -Dapplication.update=skip \
+    -Dnet.filebot.archive.extractor=ShellExecutables \
+    --illegal-access=permit \
+    --add-opens=java.base/java.lang=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+    --add-opens=java.base/java.util=ALL-UNNAMED \
+    --add-opens=java.base/java.util.function=ALL-UNNAMED \
+    --add-opens=java.base/java.util.regex=ALL-UNNAMED \
+    --add-opens=java.base/java.net=ALL-UNNAMED \
+    --add-opens=java.base/java.io=ALL-UNNAMED \
+    --add-opens=java.base/java.nio=ALL-UNNAMED \
+    --add-opens=java.base/java.nio.file=ALL-UNNAMED \
+    --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED \
+    --add-opens=java.base/java.nio.channels=ALL-UNNAMED \
+    --add-opens=java.base/java.nio.charset=ALL-UNNAMED \
+    --add-opens=java.base/java.time=ALL-UNNAMED \
+    --add-opens=java.base/java.time.chrono=ALL-UNNAMED \
+    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+    --add-opens=java.base/java.text=ALL-UNNAMED \
+    --add-opens=java.base/sun.nio.fs=ALL-UNNAMED \
+    --add-opens=java.logging/java.util.logging=ALL-UNNAMED \
+    --add-opens=java.desktop/java.awt=ALL-UNNAMED \
+    --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
+    --add-opens=java.desktop/sun.swing=ALL-UNNAMED \
+    --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED \
+    --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
+    -Djna.boot.library.path="${LIBRARY_PATH}" \
+    -Djna.library.path="${LIBRARY_PATH}" \
+    -Djava.library.path="${LIBRARY_PATH}" \
+    -Dapplication.dir="${APP_DATA}" \
+    -Dapplication.cache="${APP_DATA}/cache" \
+    -Djava.io.tmpdir="${APP_DATA}/tmp" \
+    -Dfile.encoding="UTF-8" \
+    -Dsun.jnu.encoding="UTF-8" \
+    -Dprism.order=sw \
+    -Dnet.filebot.theme=Darcula \
+    -DuseGVFS=true \
+    -Dnet.filebot.gio.GVFS="${XDG_RUNTIME_DIR}/gvfs" \
+    "${JAVA_OPTS[@]}" \
+    "${FILEBOT_OPTS[@]}" \
+    -jar "${FILEBOT_HOME}/jar/filebot.jar" \
+    "$@"


### PR DESCRIPTION
This PR introduces PGP verification of the official PGP key, verifies the sources by their SHA256 (instead of MD5) and other readability improvements. (The key is the one from [filebot/KEYS](https://get.filebot.net/filebot/KEYS))

- Use PGP (you might to import: `gpg --recv-keys B0976E51E5C047AD0FD051294E402EBF7C3C6A71`)
- Use SHA256 instead of MD5
- In the `filebot.sh` and `filebot.install` applied shellcheck suggestions
- Split very long line over multiple lines to increase readability