### PR TITLE
Use Java 17 (instead of 11)

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = filebot
 	pkgdesc = The ultimate TV and Movie Renamer
 	pkgver = 5.0.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.filebot.net/
 	install = filebot.install
 	arch = i686
@@ -10,8 +10,8 @@ pkgbase = filebot
 	arch = armv7l
 	arch = armv7h
 	license = Commercial
-	depends = jre11-openjdk
-	depends = java11-openjfx>=11.0.10.u1
+	depends = jre17-openjdk
+	depends = java17-openjfx
 	depends = fontconfig
 	depends = chromaprint
 	optdepends = libzen: Required by libmediainfo
@@ -26,6 +26,6 @@ pkgbase = filebot
 	validpgpkeys = B0976E51E5C047AD0FD051294E402EBF7C3C6A71
 	sha256sums = 0abf1e8da4676363492a09e6d5810c50f0b9d053cab81a35b4005faafa1eebbd
 	sha256sums = SKIP
-	sha256sums = cf902ce1b126706d7f1c4bb3bb32002ed2c12170d97b13070f8a1202a2e6b123
+	sha256sums = 3a6912ed9b49c3bd686913e90987649614c4c197855b6bb31e421da24fcbc3d5
 
 pkgname = filebot

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -8,12 +8,12 @@
 
 pkgname=filebot
 pkgver=5.0.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The ultimate TV and Movie Renamer"
 arch=('i686' 'x86_64' 'aarch64' 'armv7l' 'armv7h')
 url="https://www.filebot.net/"
 license=('Commercial')
-depends=('jre11-openjdk' 'java11-openjfx>=11.0.10.u1' 'fontconfig' 'chromaprint')
+depends=('jre17-openjdk' 'java17-openjfx' 'fontconfig' 'chromaprint')
 makedepends=()
 checkdepends=()
 
@@ -32,8 +32,8 @@ source=(
 )
 
 sha256sums=('0abf1e8da4676363492a09e6d5810c50f0b9d053cab81a35b4005faafa1eebbd'
-            'abefbc697ebab05556f955a66b634bcd30420ca7632901f648f20c23b181a041'
-            'cf902ce1b126706d7f1c4bb3bb32002ed2c12170d97b13070f8a1202a2e6b123')
+            'SKIP'
+            '3a6912ed9b49c3bd686913e90987649614c4c197855b6bb31e421da24fcbc3d5')
 validpgpkeys=('B0976E51E5C047AD0FD051294E402EBF7C3C6A71')
 
 package() {

--- a/filebot.install
+++ b/filebot.install
@@ -11,11 +11,6 @@ fi
 }
 
 post_install() {
-  echo -e "\e[1;33m==>\e[0m Symlinking OpenJFX"
-
-  ln -sf /usr/lib/jvm/java-11-openjfx/lib/ /usr/share/filebot/openjfx
-
-  echo ""
   echo -e "\e[1;33m==>\e[0m \e[1;31m filebot --license license.file \e[0m will activate your license.file"
   echo ""
 

--- a/filebot.sh
+++ b/filebot.sh
@@ -16,13 +16,12 @@ APP_DATA="${HOME}/.config/filebot"
 LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"
 MODULE_PATH="${FILEBOT_HOME}/openjfx"
 
-/usr/lib/jvm/java-11-openjdk/bin/java \
+/usr/lib/jvm/java-17-openjdk/bin/java \
     -Dapplication.deployment=aur \
     --module-path "${MODULE_PATH}" \
     --add-modules ALL-MODULE-PATH \
     -Dapplication.update=skip \
     -Dnet.filebot.archive.extractor=ShellExecutables \
-    --illegal-access=permit \
     --add-opens=java.base/java.lang=ALL-UNNAMED \
     --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
     --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \


### PR DESCRIPTION
The main reason for this PR is that `java11-openjfx` was dropped to the AUR: https://aur.archlinux.org/packages/java11-openjfx

Please verify that it's working before merging (or close if unwanted).

I'm only using Filebot for renaming on the terminal (no GUI, none of the advanced features), so I don't know if it actually requires Java 11 for these features.

However, I can at least confirm that the CLI application is working with Java 20 (and also Java 17) but I don't know how to represent this either/or requirement in the PKGBUILD.


If you want to stay with the LTS version, you could change to Java 17.

