### PR TITLE
Cleanup: Remove openjfx, depend on latest java, cleanup

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = filebot
 	pkgdesc = The ultimate TV and Movie Renamer
 	pkgver = 5.1.2
-	pkgrel = 1
+	pkgrel = 2
 	url = https://www.filebot.net/
 	install = filebot.install
 	arch = i686
@@ -10,8 +10,7 @@ pkgbase = filebot
 	arch = armv7l
 	arch = armv7h
 	license = Commercial
-	depends = jre17-openjdk
-	depends = java17-openjfx
+	depends = java-runtime
 	depends = fontconfig
 	depends = chromaprint
 	optdepends = libzen: Required by libmediainfo
@@ -26,6 +25,6 @@ pkgbase = filebot
 	validpgpkeys = B0976E51E5C047AD0FD051294E402EBF7C3C6A71
 	sha256sums = f8acf7af5d6aa992b6aed1d41caf484cae967ed6cb0d501656ba82d3f22c736a
 	sha256sums = SKIP
-	sha256sums = 7876c203315d8f6f59ed4c71ef22594fad19cb0bff7044d0cf724a25ce137d7c
+	sha256sums = 3c05e7ac0f2268a42dccc9158081022db857c656f8350d33518bc7ad7ac17a3a
 
 pkgname = filebot

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+shell_variant = bash
+keep_padding = true
+case_indent = true

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,12 +9,12 @@
 
 pkgname=filebot
 pkgver=5.1.2
-pkgrel=1
+pkgrel=2
 pkgdesc="The ultimate TV and Movie Renamer"
 arch=('i686' 'x86_64' 'aarch64' 'armv7l' 'armv7h')
 url="https://www.filebot.net/"
 license=('Commercial')
-depends=('jre17-openjdk' 'java17-openjfx' 'fontconfig' 'chromaprint')
+depends=('java-runtime' 'fontconfig' 'chromaprint')
 makedepends=()
 checkdepends=()
 
@@ -26,21 +26,19 @@ provides=('filebot')
 
 conflicts=('filebot47' 'filebot-git')
 install=$pkgname.install
-source=(
-    "https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz"
-    "https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz.asc"
-    "filebot.sh"
-)
+source=("https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz"
+        "https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur.tar.xz.asc"
+        "filebot.sh")
 
 sha256sums=('f8acf7af5d6aa992b6aed1d41caf484cae967ed6cb0d501656ba82d3f22c736a'
             'SKIP'
-            '7876c203315d8f6f59ed4c71ef22594fad19cb0bff7044d0cf724a25ce137d7c')
+            '3c05e7ac0f2268a42dccc9158081022db857c656f8350d33518bc7ad7ac17a3a')
 validpgpkeys=('B0976E51E5C047AD0FD051294E402EBF7C3C6A71')
 
 package() {
   mkdir -p "${pkgdir}/usr/bin"
   mkdir -p "${pkgdir}/usr/share/${pkgname}"
- 
+
   install -Dm755 "${pkgname}.sh" "${pkgdir}/usr/bin/${pkgname}"
 
   cp -dpr --no-preserve=ownership "${srcdir}/etc" "${srcdir}/usr" "${pkgdir}"

--- a/filebot.install
+++ b/filebot.install
@@ -1,20 +1,16 @@
-# vim: set syntax=bash :
-pre_install () {
-if [ -d "/usr/share/filebot/openjfx" ]; then
-  if [ -L "/usr/share/filebot/openjfx" ]; then
-    echo "Installing"
-  else
-    echo "Removing /usr/share/filebot/openjfx directory leftover"
-    rm -r /usr/share/filebot/openjfx
+#!/usr/bin/env bash
+pre_install() {
+  if [ -d "/usr/share/filebot/openjfx" ]; then
+    if [ -L "/usr/share/filebot/openjfx" ]; then
+      echo "Installing"
+    else
+      echo "Removing /usr/share/filebot/openjfx directory leftover"
+      rm -r /usr/share/filebot/openjfx
+    fi
   fi
-fi
 }
 
 post_install() {
-  # echo -e "\e[1;33m==>\e[0m Symlinking OpenJFX"
-
-  # ln -sf /usr/lib/jvm/java-11-openjfx/lib/ /usr/share/filebot/openjfx
-
   echo ""
   echo -e "\e[1;33m==>\e[0m \e[1;31m filebot --license license.file \e[0m will activate your license.file"
   echo ""
@@ -25,7 +21,7 @@ post_install() {
   echo ""
 }
 
-pre_upgrade () {
+pre_upgrade() {
   pre_install "${1}"
 }
 

--- a/filebot.sh
+++ b/filebot.sh
@@ -3,112 +3,62 @@ FILEBOT_HOME="/usr/share/filebot"
 
 # sanity check
 if [ -z "${HOME}" ]; then
-	echo "\$HOME must be set"
-	exit 1
+  echo "\$HOME must be set"
+  exit 1
 fi
 
 if [ "$(id -u)" = "0" ]; then
-	echo "$0 must NOT run as root"
+  echo "$0 must NOT run as root"
 fi
 
 # select application data folder
 APP_DATA="${HOME}/.config/filebot"
 LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"
-MODULE_PATH="${FILEBOT_HOME}/openjfx"
 
-# /usr/lib/jvm/java-11-openjdk/bin/java
-
-# /usr/bin/java \
-#     -Dapplication.deployment=aur \
-#     --module-path "${MODULE_PATH}" \
-#     --add-modules ALL-MODULE-PATH \
-#     -Dapplication.update=skip \
-#     -Dnet.filebot.archive.extractor=ShellExecutables \
-#     --add-opens=java.base/java.lang=ALL-UNNAMED \
-#     --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
-#     --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
-#     --add-opens=java.base/java.util=ALL-UNNAMED \
-#     --add-opens=java.base/java.util.function=ALL-UNNAMED \
-#     --add-opens=java.base/java.util.regex=ALL-UNNAMED \
-#     --add-opens=java.base/java.net=ALL-UNNAMED \
-#     --add-opens=java.base/java.io=ALL-UNNAMED \
-#     --add-opens=java.base/java.nio=ALL-UNNAMED \
-#     --add-opens=java.base/java.nio.file=ALL-UNNAMED \
-#     --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED \
-#     --add-opens=java.base/java.nio.channels=ALL-UNNAMED \
-#     --add-opens=java.base/java.nio.charset=ALL-UNNAMED \
-#     --add-opens=java.base/java.time=ALL-UNNAMED \
-#     --add-opens=java.base/java.time.chrono=ALL-UNNAMED \
-#     --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
-#     --add-opens=java.base/java.text=ALL-UNNAMED \
-#     --add-opens=java.base/sun.nio.fs=ALL-UNNAMED \
-#     --add-opens=java.logging/java.util.logging=ALL-UNNAMED \
-#     --add-opens=java.desktop/java.awt=ALL-UNNAMED \
-#     --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
-#     --add-opens=java.desktop/sun.swing=ALL-UNNAMED \
-#     --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED \
-#     --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
-#     -Djna.boot.library.path="${LIBRARY_PATH}" \
-#     -Djna.library.path="${LIBRARY_PATH}" \
-#     -Djava.library.path="${LIBRARY_PATH}" \
-#     -Dapplication.dir="${APP_DATA}" \
-#     -Dapplication.cache="${APP_DATA}/cache" \
-#     -Djava.io.tmpdir="${APP_DATA}/tmp" \
-#     -Dfile.encoding="UTF-8" \
-#     -Dsun.jnu.encoding="UTF-8" \
-#     -Dprism.order=sw \
-#     -Dnet.filebot.theme=Darcula \
-#     -DuseGVFS=true \
-#     -Dnet.filebot.gio.GVFS="${XDG_RUNTIME_DIR}/gvfs" \
-#     "${JAVA_OPTS[@]}" \
-#     "${FILEBOT_OPTS[@]}" \
-#     -jar "${FILEBOT_HOME}/jar/filebot.jar" \
-#     "$@"
-
+# shellcheck disable=SC2086
 java \
-    -Dapplication.deployment=aur \
-    --module-path "$MODULE_PATH" \
-    --add-modules ALL-MODULE-PATH \
-    -Dnet.filebot.archive.extractor=ShellExecutables \
-    --add-opens=java.base/java.lang=ALL-UNNAMED \
-    --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
-    --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
-    --add-opens=java.base/java.util=ALL-UNNAMED \
-    --add-opens=java.base/java.util.function=ALL-UNNAMED \
-    --add-opens=java.base/java.util.regex=ALL-UNNAMED \
-    --add-opens=java.base/java.net=ALL-UNNAMED \
-    --add-opens=java.base/java.io=ALL-UNNAMED \
-    --add-opens=java.base/java.nio=ALL-UNNAMED \
-    --add-opens=java.base/java.nio.file=ALL-UNNAMED \
-    --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED \
-    --add-opens=java.base/java.nio.channels=ALL-UNNAMED \
-    --add-opens=java.base/java.nio.charset=ALL-UNNAMED \
-    --add-opens=java.base/java.time=ALL-UNNAMED \
-    --add-opens=java.base/java.time.chrono=ALL-UNNAMED \
-    --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
-    --add-opens=java.base/java.text=ALL-UNNAMED \
-    --add-opens=java.base/sun.nio.fs=ALL-UNNAMED \
-    --add-opens=java.logging/java.util.logging=ALL-UNNAMED \
-    --add-opens=java.desktop/java.awt=ALL-UNNAMED \
-    --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
-    --add-opens=java.desktop/sun.swing=ALL-UNNAMED \
-    --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED \
-    --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
-    -XX:+DisableAttachMechanism \
-    -Djna.boot.library.path="$LIBRARY_PATH" \
-    -Djna.boot.library.name=jnidispatch \
-    -Djna.library.path="$LIBRARY_PATH" \
-    -Djava.library.path="$LIBRARY_PATH" \
-    -Dapplication.dir="$APP_DATA" \
-    -Dapplication.cache="$APP_DATA/cache" \
-    -Djava.io.tmpdir="$APP_DATA/tmp" \
-    -Dfile.encoding="UTF-8" \
-    -Dsun.jnu.encoding="UTF-8" \
-    -Dawt.useSystemAAFontSettings=on \
-    -Dprism.order=sw \
-    -Dnet.filebot.theme=Darcula \
-    -DuseGVFS=true \
-    -Dnet.filebot.gio.GVFS="$XDG_RUNTIME_DIR/gvfs" \
-    $JVM_OPTS $JAVA_OPTS $FILEBOT_OPTS \
-    -jar "$FILEBOT_HOME/jar/filebot.jar" \
-    "$@"
+  -Dapplication.deployment=aur \
+  --add-modules ALL-MODULE-PATH \
+  -Dnet.filebot.archive.extractor=ShellExecutables \
+  --add-opens=java.base/java.lang=ALL-UNNAMED \
+  --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  --add-opens=java.base/java.util.function=ALL-UNNAMED \
+  --add-opens=java.base/java.util.regex=ALL-UNNAMED \
+  --add-opens=java.base/java.net=ALL-UNNAMED \
+  --add-opens=java.base/java.io=ALL-UNNAMED \
+  --add-opens=java.base/java.nio=ALL-UNNAMED \
+  --add-opens=java.base/java.nio.file=ALL-UNNAMED \
+  --add-opens=java.base/java.nio.file.attribute=ALL-UNNAMED \
+  --add-opens=java.base/java.nio.channels=ALL-UNNAMED \
+  --add-opens=java.base/java.nio.charset=ALL-UNNAMED \
+  --add-opens=java.base/java.time=ALL-UNNAMED \
+  --add-opens=java.base/java.time.chrono=ALL-UNNAMED \
+  --add-opens=java.base/java.util.concurrent=ALL-UNNAMED \
+  --add-opens=java.base/java.text=ALL-UNNAMED \
+  --add-opens=java.base/sun.nio.fs=ALL-UNNAMED \
+  --add-opens=java.logging/java.util.logging=ALL-UNNAMED \
+  --add-opens=java.desktop/java.awt=ALL-UNNAMED \
+  --add-opens=java.desktop/sun.awt=ALL-UNNAMED \
+  --add-opens=java.desktop/sun.swing=ALL-UNNAMED \
+  --add-opens=java.desktop/javax.swing.text.html=ALL-UNNAMED \
+  --add-opens=java.prefs/java.util.prefs=ALL-UNNAMED \
+  -XX:+DisableAttachMechanism \
+  -Djna.boot.library.path="${LIBRARY_PATH}" \
+  -Djna.boot.library.name=jnidispatch \
+  -Djna.library.path="${LIBRARY_PATH}" \
+  -Djava.library.path="${LIBRARY_PATH}" \
+  -Dapplication.dir="${APP_DATA}" \
+  -Dapplication.cache="${APP_DATA}/cache" \
+  -Djava.io.tmpdir="${APP_DATA}/tmp" \
+  -Dfile.encoding="UTF-8" \
+  -Dsun.jnu.encoding="UTF-8" \
+  -Dawt.useSystemAAFontSettings=on \
+  -Dprism.order=sw \
+  -Dnet.filebot.theme=Darcula \
+  -DuseGVFS=true \
+  -Dnet.filebot.gio.GVFS="${XDG_RUNTIME_DIR}/gvfs" \
+  ${JVM_OPTS} ${JAVA_OPTS} ${FILEBOT_OPTS} \
+  -jar "${FILEBOT_HOME}/jar/filebot.jar" \
+  "$@"


### PR DESCRIPTION
This commit does basically the same as #23 by removing openjfx from the dependencies.

However, it also updates the java version to the generic `java-runtime` where the user can choose JRE or JDK which is now the default for versions >= 21.

(Reformatting and removing commented source code is also included.)