### PR TITLE
filebot.sh: Force xwayland over wayland, fixes GUID issues on wayland

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -32,7 +32,7 @@ source=("https://get.filebot.net/filebot/FileBot_${pkgver}/FileBot_${pkgver}-aur
 
 sha256sums=('f8acf7af5d6aa992b6aed1d41caf484cae967ed6cb0d501656ba82d3f22c736a'
             'SKIP'
-            '3c05e7ac0f2268a42dccc9158081022db857c656f8350d33518bc7ad7ac17a3a')
+            'da91e22b0bc2bfda035ca0bb8e277e93d3bf4436c540938be52105a383317018')
 validpgpkeys=('B0976E51E5C047AD0FD051294E402EBF7C3C6A71')
 
 package() {

--- a/filebot.sh
+++ b/filebot.sh
@@ -11,6 +11,9 @@ if [ "$(id -u)" = "0" ]; then
   echo "$0 must NOT run as root"
 fi
 
+# Disable wayland to force xwayland
+WAYLAND_DISPLAY=
+
 # select application data folder
 APP_DATA="${HOME}/.config/filebot"
 LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"


### PR DESCRIPTION
This unsets the WAYLAND_DISPLAY env variable in the launcher script, which causes a fallback to x11 (xwayland) on native wayland desktops. The variable has no effect on x11 setups.

Fixes a GUI bug (see [filebot forums](https://www.filebot.net/forums/viewtopic.php?t=13567)) that I also encounter on kde+wayland+nvidia.

Feel free to close/reject if this kind of fix is too broad or hacky for you.