### PR TITLE
Set _JAVA_AWT_WM_NONREPARENTING=1 on Wayland to fix blank FileBot UI on sway 

### DIFF
--- a/filebot.sh
+++ b/filebot.sh
@@ -24,7 +24,7 @@ WAYLAND_DISPLAY=
 # see https://github.com/arch-noob/filebot/issues/30
 # see https://wiki.archlinux.org/title/Java
 if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
-    _JAVA_AWT_WM_NONREPARENTING=1
+    export _JAVA_AWT_WM_NONREPARENTING=1
 fi
 
 # shellcheck disable=SC2086

--- a/filebot.sh
+++ b/filebot.sh
@@ -20,6 +20,13 @@ LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"
 # as of 09.03.2024 seems relevant under KDE 6.0 using Wayland and nvidia/amd gpu
 WAYLAND_DISPLAY=
 
+# Force _JAVA_AWT_WM_NONREPARENTING for wayland to avoid gray / blank screen
+# see https://github.com/arch-noob/filebot/issues/30
+# see https://wiki.archlinux.org/title/Java
+if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
+    _JAVA_AWT_WM_NONREPARENTING=1
+fi
+
 # shellcheck disable=SC2086
 java \
   -Dapplication.deployment=aur \

--- a/filebot.sh
+++ b/filebot.sh
@@ -21,8 +21,8 @@ LIBRARY_PATH="${FILEBOT_HOME}/lib/$(uname -m):/lib64"
 WAYLAND_DISPLAY=
 
 # Force _JAVA_AWT_WM_NONREPARENTING for wayland to avoid gray / blank screen
-# see https://github.com/arch-noob/filebot/issues/30
-# see https://wiki.archlinux.org/title/Java
+# see https://github.com/arch-noob/filebot/issues/30 and https://wiki.archlinux.org/title/Java
+# relevant for sway or any other non-opiononated window manager
 if [[ "$XDG_SESSION_TYPE" == "wayland" ]]; then
     export _JAVA_AWT_WM_NONREPARENTING=1
 fi


### PR DESCRIPTION
To fix the blank FileBot UI issue on Wayland, try setting the environment variable ` _JAVA_AWT_WM_NONREPARENTING` to `1`. 

This problem occurs with Java's AWT on Wayland, with window managers like Sway, which don't set defaults for java window reparenting.  By setting the value we are able to resolve the issue of the FileBot window appearing blank or grey. For more details, check out the related bug report: #30.