### PR TITLE
helper script for installing latest filebot

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Define the URL for the update.xml file
+UPDATE_URL="https://app.filebot.net/update.xml"
+
+# Fetch the latest version from update.xml
+latest_version=$(wget -qO- "$UPDATE_URL" | grep -oP '(?<=<name>FileBot ).*(?=</name>)')
+
+if [ -z "$latest_version" ]; then
+  echo "Error: Could not find the latest version in update.xml."
+  exit 1
+fi
+
+# Define the PKGBUILD file
+PKGBUILD="PKGBUILD"
+
+# Update only the pkgver in PKGBUILD
+sed -i "s/^pkgver=.*/pkgver=$latest_version/" "$PKGBUILD"
+
+# Update checksums
+updpkgsums
+
+# Install
+makepkg -si

--- a/install-latest.sh
+++ b/install-latest.sh
@@ -21,4 +21,4 @@ sed -i "s/^pkgver=.*/pkgver=$latest_version/" "$PKGBUILD"
 updpkgsums
 
 # Install
-makepkg -si
+makepkg -si --skipinteg


### PR DESCRIPTION
sometimes the package ver is outdated. This script would make it possible to always install the latest filebot.
I would not touch the PKGBUILD as it must work offline.
This is additional.